### PR TITLE
fix pinch gesture on windows

### DIFF
--- a/CameraTest.tscn
+++ b/CameraTest.tscn
@@ -82,3 +82,4 @@ limit_top = -1000
 limit_right = 2920
 limit_bottom = 1980
 script = ExtResource( 2 )
+handle_mouse_events = false

--- a/TouchCamera2D.gd
+++ b/TouchCamera2D.gd
@@ -137,10 +137,12 @@ func _unhandled_input(event: InputEvent) -> void:
 			set_position(position - event.relative * zoom)
 
 		# If there are more than one finger on screen
-		if events.size() == 2 and events.has_all([0, 1]):
+		if events.size() > 1:
+			# Get index (this is random with window 10 touch)
+			var keys = events.keys()
 			# Stores the touches position
-			var p1: Vector2 = events[0].position
-			var p2: Vector2 = events[1].position
+			var p1: Vector2 = events[keys[0]].position
+			var p2: Vector2 = events[keys[1]].position
 
 			# If move while zooming is set true
 			if move_while_zooming:


### PR DESCRIPTION
I tested your code on my windows 10 multitouch laptop and unfortunately pinch zoom didn't work.
The problem seems to come from the fact that the events array has random indexes, similar to what someone else described here:https://godotengine.org/qa/35453/windows-inputeventscreentouch-events-have-weird-indexes
This could be easily fixed by using the keys of the array and should work on Android/IPhone too (not tested yet)