### PR TITLE
Zoom by trackpad relative speed to pinch movement

### DIFF
--- a/TouchCamera2D.gd
+++ b/TouchCamera2D.gd
@@ -306,9 +306,11 @@ func _unhandled_input(event: InputEvent) -> void:
 				zoom_in = event.delta.y > 0
 				zoom_out = event.delta.y < 0
 			elif zoom_by_trackpad:
-				zoom_in = event.factor > 1
-				zoom_out = event.factor < 1
-			
+				var distance = (1 - event.factor)
+				var zoom_position = event.position if zoom_at_point else position
+				zoom_at(zoom + Vector2(distance, distance), zoom_position)
+				return
+
 			# Wheel up = zoom-in
 			if zoom_in:
 				if zoom_at_point:


### PR DESCRIPTION
`mouse_zoom_increment` is fixed speed, but you can achieve a much more smooth scroll when moving at a rate relative to the pinch motion of the fingers. This way it behaves similarly to native macOS apps and the Godot editor. Wasn't 100% sure if maybe there should be an extra setting (`trackpad_zoom_multiplier`?) if customisation is still wanted on the speed, but at the very least I don't think it makes sense to couple it in with the increment for mouse wheel.

Looking at the surrounding lines, it looks like `zoom_by_touch_scroll` could do with a similar change, but I haven't got a touch device setup to try.

It might also make sense to have some kind of mode state. E.g. a "mouse mode" / "trackpad mode" because it's a bit odd to support 2 fingers up/down as well as pinch at the same time (also ideally 2 fingers on trackpad drag would also pan). Different states might help resolve your `Emulating touch from mouse` issue described in the readme too. Ideally automatically detected (e.g. switch to trackpad mode on any occurrence of `InputEventMagnifyGesture`) but I'm not 100% sure how easy that would be.

I might experiment a bit more if you're open to my ideas.