### PR TITLE
Zoom improvements

### DIFF
--- a/TouchCamera2D.gd
+++ b/TouchCamera2D.gd
@@ -444,12 +444,6 @@ func zoom_at(new_zoom: Vector2, point: Vector2) -> void:
 	var zoom_diff: Vector2
 	zoom_diff = new_zoom - zoom
 
-	# For some reason, sometimes the calculation for the next_zoom loses 0.000001
-	# e.g. instead of increasing from 1.50 to 1.55 it changes to 1.549999 which
-	# causes weird behaviours when changing the zoom. Stepifying new_zoom.x
-	# prevents it
-	new_zoom.x = stepify(new_zoom.x, 0.01)
-
 	# If the camera's anchor is set to center
 	if anchor_mode == ANCHOR_MODE_DRAG_CENTER:
 		# Updates the focused point value to be relative to the center


### PR DESCRIPTION
This PR includes 2 things:
* Prevent movement when trying to scroll beyond the minimum or maximum - previously if you scroll all the way in, and continue trying to zoom, the zoom level remains but the position changes
* Prevent extra sliding while zooming - I'm not sure what this `stepify` call was originally trying to fix, but with it the new position moves slightly away from the `point`. I know there was a comment detailing there was a problem with floating point, but it seems to cause more problems than it solves at least on my machine 

With the caveat I've only tested on macOS using a trackpad, but both zoom 2 fingers up/down as well as pinch are improved by these